### PR TITLE
fix: dont broadcast locally when using a transport

### DIFF
--- a/src/transmit.ts
+++ b/src/transmit.ts
@@ -172,13 +172,14 @@ export class Transmit {
       payload = {}
     }
 
-    this.#broadcastLocally(channel, payload)
-
-    // @ts-ignore
-    void this.#transport?.send(this.#config.transport.channel, {
-      channel,
-      payload,
-    })
+    if (this.#transport) {
+      void this.#transport.send(this.#config.transport!.channel!, {
+        channel,
+        payload,
+      })
+    } else {
+      this.#broadcastLocally(channel, payload)
+    }
 
     void this.#emittery.emit('broadcast', { channel, payload })
   }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using a transport an event was broadcasted twice. Since it was sent to the transport and emitted locally and then emitted again when received from the transport.

Now the event will only be emitted locally when no transport is configured.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
