### PR TITLE
Docs: Add GZip exclusion instructions for Transmit SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Here are a few things you should know before using this module.
 - [Syncing](#syncing)
 - [Ping](#ping)
 - [Events](#events)
+- [Avoiding GZip Interference](#avoiding-gzip-interference)
+
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -172,6 +174,21 @@ transmit.on('unsubscribe', ({ uid, channel }) => {
   console.log(`Unsubscribed ${uid} from ${channel}`)
 })
 ```
+
+# Avoiding GZip Interference
+
+When deploying applications that use `@adonisjs/transmit`, it’s important to ensure that GZip compression does not interfere with the `text/event-stream` content type used by Server-Sent Events (SSE). Compression applied to `text/event-stream` can cause connection issues, leading to frequent disconnects or SSE failures.
+
+If your deployment uses a reverse proxy (such as Traefik or Nginx) or other middleware that applies GZip, ensure that compression is disabled for the `text/event-stream` content type.
+
+## Example Configuration for Traefik
+
+```plaintext
+traefik.http.middlewares.gzip.compress=true
+traefik.http.middlewares.gzip.compress.excludedcontenttypes=text/event-stream
+traefik.http.routers.my-router.middlewares=gzip
+```
+
 
 [gh-workflow-image]: https://img.shields.io/github/actions/workflow/status/adonisjs/transmit/test.yml?branch=main&style=for-the-badge
 [gh-workflow-url]: https://github.com/adonisjs/transmit/actions/workflows/test.yml 'GitHub action'


### PR DESCRIPTION
### 🔗 Linked issue

- https://github.com/adonisjs/transmit/issues/31

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR updates the documentation to address issues caused by GZip compression interfering with Server-Sent Events (SSE) when using `@adonisjs/transmit`. It explains how to disable GZip for the `text/event-stream` content type while keeping compression enabled for other content types. 

### Changes
1. Added a new section: "Avoiding GZip Interference" in the `transmit.md` file.
2. Included configuration examples for:
   - **Traefik**: Demonstrates how to use the `excludedcontenttypes` option.
   
### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
