### PR TITLE
fix: correct RuntimeException import (#41)

### DIFF
--- a/src/controllers/event_stream_controller.ts
+++ b/src/controllers/event_stream_controller.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { RuntimeException } from '@poppinss/utils/exception'
+import { RuntimeException } from '@poppinss/exception'
 import transmit from '../../services/transmit.js'
 import type { HttpContext } from '@adonisjs/core/http'
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue
#41 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The `RuntimeException` class was being imported from `@poppinss/utils/exception`, which does not (or no longer) export it, leading to an undefined reference and runtime/build errors.

This pull request updates the import to point to `@poppinss/exception`, which is the correct and dedicated package for this class.
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
